### PR TITLE
Chargen updates/hp calc/roll/starting characters

### DIFF
--- a/commands/character_commands.py
+++ b/commands/character_commands.py
@@ -20,7 +20,7 @@ from world.inventory.models import Weapon, Armor, Gear, Inventory
 from evennia.commands.default.muxcommand import MuxCommand
 from world.lifepath_dictionary import CULTURAL_ORIGINS, PERSONALITIES, CLOTHING_STYLES, HAIRSTYLES, AFFECTATIONS, MOTIVATIONS, LIFE_GOALS, ROLE_SPECIFIC_LIFEPATHS, VALUED_PERSON, VALUED_POSSESSION, FAMILY_BACKGROUND, ENVIRONMENT, FAMILY_CRISIS
 from world.utils.difficulty_values import parse_dv
-from world.improvement_points import get_character_stat_value
+from world.improvement_points import get_character_stat_value, get_stat_display_name
 from math import ceil
 
 class CmdSheet(MuxCommand):
@@ -746,6 +746,10 @@ class CmdRoll(MuxCommand):
     Difficulty names: Simple (9), Everyday (13), Difficult (15), Professional (17),
     Heroic (21), Incredible (24), Legendary (29).
 
+    For skills with instances (Local Expert, Play Instrument, Martial Arts), specify the instance:
+      roll Cool + local expert (The Net)
+      roll Cool + local expert (Night City)
+
     Examples:
       roll Reflexes + Handgun
       roll Credibility + Cool
@@ -861,8 +865,8 @@ class CmdRoll(MuxCommand):
             char = self.caller
             attr_value = self._get_stat_value(char, full_first, is_stat=True)
             skill_value = self._get_stat_value(char, full_second, is_stat=False)
-            attr_display = full_first.replace('_', ' ').title()
-            skill_display = full_second.replace('_', ' ').title()
+            attr_display = get_stat_display_name(full_first) or full_first.replace('_', ' ').title()
+            skill_display = get_stat_display_name(full_second) or full_second.replace('_', ' ').title()
 
         # Luck check
         if luck_spend > 0:
@@ -979,8 +983,8 @@ class CmdRoll(MuxCommand):
         char = self.caller
         attr_value = self._get_stat_value(char, full_first, is_stat=True)
         skill_value = self._get_stat_value(char, full_second, is_stat=False)
-        attr_display = full_first.replace("_", " ").title()
-        skill_display = full_second.replace("_", " ").title()
+        attr_display = get_stat_display_name(full_first) or full_first.replace("_", " ").title()
+        skill_display = get_stat_display_name(full_second) or full_second.replace("_", " ").title()
 
         from world.utils.roll_utils import roll_skill_check, check_success, format_roll_details
         from world.wound_utils import get_action_penalty

--- a/commands/chargen.py
+++ b/commands/chargen.py
@@ -655,7 +655,8 @@ class CmdChargen(MuxCommand):
         char.db.body = 1
         char.db.empathy = 1
 
-        char.db.max_hp = 10 + (5 * ((char.db.body + char.db.willpower) // 2))
+        from world.hp_chart import get_hp_from_chart
+        char.db.max_hp = get_hp_from_chart(char.db.body, char.db.willpower)
         char.db.current_hp = char.db.max_hp
         char.db.humanity = char.db.empathy * 10
         char.db.humanity_loss = 0

--- a/typeclasses/characters.py
+++ b/typeclasses/characters.py
@@ -52,7 +52,8 @@ class Character(DefaultCharacter):
         self.db.empathy = 1
         
         # Derived stats
-        self.db.max_hp = 10 + (5 * ((self.db.body + self.db.willpower) // 2))
+        from world.hp_chart import get_hp_from_chart
+        self.db.max_hp = get_hp_from_chart(self.db.body, self.db.willpower)
         self.db.current_hp = self.db.max_hp
         self.db.humanity = self.db.empathy * 10
         self.db.humanity_loss = 0
@@ -202,6 +203,9 @@ class Character(DefaultCharacter):
      
         # Initialize skill instances dictionary
         self.db.skill_instances = {}
+
+        # Languages dict for add_language/languages property (chargen adds Streetslang via add_language)
+        self.db.languages = {}
 
         # Do NOT create character sheet here - it is created when the player runs chargen
         # for the first time. This prevents new characters from being prompted to reset.
@@ -617,8 +621,8 @@ class Character(DefaultCharacter):
     
     def recalculate_derived_stats(self):
         """Recalculate all derived statistics."""
-        # Calculate max HP
-        self.db.max_hp = 10 + (5 * ((self.db.body + self.db.willpower) // 2))
+        from world.hp_chart import get_hp_from_chart
+        self.db.max_hp = get_hp_from_chart(self.db.body, self.db.willpower)
         
         # Ensure current HP doesn't exceed max HP
         if self.db.current_hp > self.db.max_hp:
@@ -1061,26 +1065,27 @@ class Character(DefaultCharacter):
     # Language-related methods
     def add_language(self, language_name, level):
         """Add a language to the character."""
-        # Initialize languages dict if not exists
-        if not hasattr(self.db, 'languages'):
-            self.db.languages = {}
-        
+        # Initialize languages dict if not exists or is None (brand-new chars may not have at_object_creation run)
+        languages = getattr(self.db, 'languages', None)
+        if languages is None or not isinstance(languages, dict):
+            languages = {}
+            self.db.languages = languages
+
         # Add the language with its level
-        languages = self.db.languages
         languages[language_name] = level
         self.db.languages = languages
-        
+
         # For backward compatibility, also update CharacterSheet if it exists
         if self.character_sheet:
             self.character_sheet.add_language(language_name, level)
     
     def remove_language(self, language_name):
         """Remove a language from the character."""
-        if not hasattr(self.db, 'languages'):
+        languages = getattr(self.db, 'languages', None)
+        if not languages or not isinstance(languages, dict):
             return
-        
+
         # Remove the language if it exists
-        languages = self.db.languages
         if language_name in languages:
             del languages[language_name]
             self.db.languages = languages
@@ -1098,10 +1103,11 @@ class Character(DefaultCharacter):
     
     def update_language_level(self, language_name, new_level):
         """Update the level of a language the character knows."""
-        if not hasattr(self.db, 'languages'):
-            self.db.languages = {}
-        
-        languages = self.db.languages
+        languages = getattr(self.db, 'languages', None)
+        if languages is None or not isinstance(languages, dict):
+            languages = {}
+            self.db.languages = languages
+
         languages[language_name] = new_level
         self.db.languages = languages
         
@@ -1112,14 +1118,14 @@ class Character(DefaultCharacter):
     @property
     def languages(self):
         """Get a dictionary of all languages the character knows."""
-        if not hasattr(self.db, 'languages'):
-            self.db.languages = {}
-            
+        languages = getattr(self.db, 'languages', None)
+        if languages is None or not isinstance(languages, dict):
+            languages = {}
             # If we have a character sheet, initialize from it
             if self.character_sheet:
                 for lang_data in self.character_sheet.language_list:
-                    self.db.languages[lang_data['name']] = lang_data['level']
-                    
+                    languages[lang_data['name']] = lang_data['level']
+            self.db.languages = languages
         return self.db.languages
     
     @property
@@ -1169,15 +1175,16 @@ class Character(DefaultCharacter):
     # Language-related methods
     def add_language(self, language_name, level):
         """Add a language to the character."""
-        # Initialize languages dict if not exists
-        if not hasattr(self.db, 'languages'):
-            self.db.languages = {}
-        
+        # Initialize languages dict if not exists or is None (brand-new chars may not have at_object_creation run)
+        languages = getattr(self.db, 'languages', None)
+        if languages is None or not isinstance(languages, dict):
+            languages = {}
+            self.db.languages = languages
+
         # Add the language with its level
-        languages = self.db.languages
         languages[language_name] = level
         self.db.languages = languages
-        
+
         # For backward compatibility, also update CharacterSheet if it exists
         if self.character_sheet:
             self.character_sheet.add_language(language_name, level)
@@ -1239,18 +1246,41 @@ class Character(DefaultCharacter):
             pass  # Language or character-language relationship not found
 
     def get_skill_instance(self, skill_name, instance):
-        """Get a skill instance value by name and instance."""
+        """Get a skill instance value by name and instance. Lookup is case-insensitive."""
         if not self.db.skill_instances:
             return 0
-        skill_key = f"{skill_name.lower().replace(' ', '_')}({instance})"
-        return self.db.skill_instances.get(skill_key, 0)
+        base = skill_name.lower().replace(' ', '_')
+        instance_lower = (instance or "").lower().strip()
+        # Direct match first
+        skill_key = f"{base}({instance})"
+        if skill_key in (self.db.skill_instances or {}):
+            return self.db.skill_instances[skill_key]
+        # Case-insensitive match: find stored key with matching base and instance
+        for stored_key, value in (self.db.skill_instances or {}).items():
+            if "(" in stored_key and ")" in stored_key:
+                stored_base, _, stored_inst = stored_key.partition("(")
+                stored_inst = stored_inst.rstrip(")")
+                if stored_base.lower() == base and stored_inst.lower() == instance_lower:
+                    return value
+        return 0
     
     def set_skill_instance(self, skill_name, instance, value):
-        """Set a skill instance value."""
+        """Set a skill instance value. Instance is normalized to title case for consistency."""
         if not self.db.skill_instances:
             self.db.skill_instances = {}
-        skill_key = f"{skill_name.lower().replace(' ', '_')}({instance})"
-        skill_instances = self.db.skill_instances
+        base = skill_name.lower().replace(' ', '_')
+        # Normalize instance to title case so "the net" and "The Net" use the same key
+        inst_normalized = (instance or "").strip().title() if instance else ""
+        skill_key = f"{base}({inst_normalized})"
+        skill_instances = dict(self.db.skill_instances or {})
+        # Remove any existing key with same base+instance (case-insensitive) to avoid duplicates
+        for k in list(skill_instances):
+            if "(" in k and ")" in k:
+                kb, _, ki = k.partition("(")
+                ki = ki.rstrip(")")
+                if kb.lower() == base and ki.lower() == inst_normalized.lower():
+                    del skill_instances[k]
+                    break
         skill_instances[skill_key] = value
         self.db.skill_instances = skill_instances
     

--- a/typeclasses/chargen.py
+++ b/typeclasses/chargen.py
@@ -277,25 +277,70 @@ class ChargenRoom(DefaultRoom):
         """
         if moved_obj.has_account:
             if not self.check_stats_complete(moved_obj):
-                moved_obj.msg("You must set all your stats before leaving this room.")
                 return False
         return True
 
     def check_stats_complete(self, character):
         """
-        Check if all necessary stats have been set.
+        Check if chargen can be finished. Stats may be 0 (players can clear them).
+        Required skills must be >= 2: Athletics, Brawling, Concentration, Conversation,
+        Education, Evasion, First Aid, Human Perception, Language (Streetslang),
+        Local Expert (Instance), Perception, Persuasion, Stealth.
         """
-        if not hasattr(character, 'character_sheet'):
+        if not hasattr(character, 'character_sheet') or not character.character_sheet:
+            character.msg("You don't have a character sheet. Please contact an admin.")
             return False
         cs = character.character_sheet
-        required_stats = ['intelligence', 'reflexes', 'dexterity', 'technology', 'cool', 
-                        'willpower', 'luck', 'move', 'body', 'empathy']
+        from world.chargen_constants import CHARGEN_REQUIRED_SKILLS, CHARGEN_REQUIRED_SKILL_MIN
+
+        # Stats: all must be set (>= 0 is valid; prefer character.db, fallback to sheet)
+        required_stats = ['intelligence', 'reflexes', 'dexterity', 'technology', 'cool',
+                         'willpower', 'luck', 'move', 'body', 'empathy']
         try:
-            return all(getattr(cs, stat, 0) > 0 for stat in required_stats)
+            for stat in required_stats:
+                val = getattr(character.db, stat, None)
+                if val is None:
+                    val = getattr(cs, stat, None)
+                if val is None:
+                    character.msg("You must set all stats before leaving. Use 'selfstat' to allocate.")
+                    return False
         except AttributeError:
-            # Log the error and return False if any attribute is missing
-            logger.error(f"AttributeError in is_character_complete for {character}") # type: ignore
+            logger.error(f"AttributeError in check_stats_complete for {character}")
             return False
+
+        # Required skills must be >= 2
+        missing = []
+        for skill_key in CHARGEN_REQUIRED_SKILLS:
+            if skill_key == "local_expert":
+                # Local Expert (Instance): need at least one instance >= 2
+                instances = character.db.skill_instances or {}
+                max_le = 0
+                for key, val in instances.items():
+                    if key.startswith("local_expert("):
+                        max_le = max(max_le, int(val) if val is not None else 0)
+                if max_le < CHARGEN_REQUIRED_SKILL_MIN:
+                    missing.append("Local Expert (Instance)")
+            else:
+                val = character.get_skill(skill_key) if hasattr(character, 'get_skill') else 0
+                val = val or 0
+                if val < CHARGEN_REQUIRED_SKILL_MIN:
+                    display = skill_key.replace('_', ' ').title()
+                    if skill_key == "human_perception":
+                        display = "Human Perception"
+                    missing.append(display)
+
+        # Language (Streetslang) >= 2
+        streetslang = character.get_language_level("Streetslang") if hasattr(character, 'get_language_level') else 0
+        if (streetslang or 0) < CHARGEN_REQUIRED_SKILL_MIN:
+            missing.append("Language (Streetslang)")
+
+        if missing:
+            character.msg(
+                f"The following skills must be at least {CHARGEN_REQUIRED_SKILL_MIN} to finish chargen: "
+                f"{', '.join(missing)}. Use 'selfstat' to set them."
+            )
+            return False
+        return True
         
         
 # To use this custom room, you would typically put this code in a file like

--- a/typeclasses/npcs.py
+++ b/typeclasses/npcs.py
@@ -121,7 +121,8 @@ class NPC(DefaultCharacter):
         """Recalculate max_hp, death_save, serious_wounds, humanity."""
         bod = self.attributes.get("body", 1)
         wil = self.attributes.get("willpower", 1)
-        self.db.max_hp = 10 + (5 * ((bod + wil) // 2))
+        from world.hp_chart import get_hp_from_chart
+        self.db.max_hp = get_hp_from_chart(bod, wil)
         self.db.current_hp = min(max(0, self.db.current_hp), self.db.max_hp)
         if self.db.current_hp == 0:
             self.db.current_hp = self.db.max_hp

--- a/world/chargen_constants.py
+++ b/world/chargen_constants.py
@@ -11,11 +11,21 @@ CHARGEN_EURODOLLARS_COMPLETE_PACKAGE = 2550
 # Edgerunner: stats from table, 86 skill points
 COMPLETE_PACKAGE_SKILL_POOL = 86
 EDGERUNNER_SKILL_POOL = 86
-# Stats and (non-role-ability) skills: min 2, max 8
-CHARGEN_STAT_MIN = 2
+# Stats: min 0 (allow clearing), max 8
+CHARGEN_STAT_MIN = 0
 CHARGEN_STAT_MAX = 8
-CHARGEN_SKILL_MIN = 2
+# Skills: min 0 (allow clearing), max 8; required skills must be >= 2 at chargen finish
+CHARGEN_SKILL_MIN = 0
 CHARGEN_SKILL_MAX = 8
+CHARGEN_REQUIRED_SKILL_MIN = 2
+
+# Skills that must be >= CHARGEN_REQUIRED_SKILL_MIN to finish chargen
+CHARGEN_REQUIRED_SKILLS = frozenset({
+    "athletics", "brawling", "concentration", "conversation", "education",
+    "evasion", "first_aid", "human_perception", "local_expert", "perception",
+    "persuasion", "stealth",
+})
+# Language (Streetslang) is required >= 2 - checked separately via get_language_level
 # Role ability: 4 free points (not deducted from skill pool), min 4, max 8
 ROLE_ABILITY_FREE_POINTS = 4
 CHARGEN_ROLE_ABILITY_MIN = 4

--- a/world/cyberpunk_sheets/edgerunner.py
+++ b/world/cyberpunk_sheets/edgerunner.py
@@ -189,8 +189,12 @@ class EdgerunnerChargen:
         character.db.maker_invention = 0
 
         # Reset derived stats
-        character.db.max_hp = 10
-        character.db.current_hp = 10
+        from world.hp_chart import get_hp_from_chart
+        character.db.max_hp = get_hp_from_chart(
+            getattr(character.db, 'body', 1),
+            getattr(character.db, 'willpower', 1),
+        )
+        character.db.current_hp = character.db.max_hp
         character.db.humanity = 10  # Will be recalculated based on empathy
         character.db.humanity_loss = 0
         character.db.total_cyberware_humanity_loss = 0
@@ -790,7 +794,8 @@ class EdgerunnerChargen:
         if not hasattr(character.db, 'willpower'):
             character.db.willpower = 1
             
-        character.db.max_hp = 10 + (5 * ((character.db.body + character.db.willpower) // 2))
+        from world.hp_chart import get_hp_from_chart
+        character.db.max_hp = get_hp_from_chart(character.db.body, character.db.willpower)
         
         # Set current HP to max if not set
         if not hasattr(character.db, 'current_hp') or character.db.current_hp == 0:
@@ -1194,8 +1199,12 @@ class EdgerunnerChargen:
         
         # Reset other attributes
         sheet.total_cyberware_humanity_loss = 0
-        sheet._max_hp = 10
-        sheet._current_hp = 10
+        from world.hp_chart import get_hp_from_chart
+        sheet._max_hp = get_hp_from_chart(
+            getattr(sheet, 'body', 1),
+            getattr(sheet, 'willpower', 1),
+        )
+        sheet._current_hp = sheet._max_hp
         sheet.fashion_budget_remaining = 0
         sheet.sell_your_soul = False
         sheet.sell_your_soul_employer_type = ""

--- a/world/cyberpunk_sheets/models.py
+++ b/world/cyberpunk_sheets/models.py
@@ -566,7 +566,8 @@ class CharacterSheet(SharedMemoryModel):
             logger.info("CharacterSheet saved")
 
     def recalculate_derived_stats(self):
-        self._max_hp = 10 + (5 * ((self.body + self.willpower) // 2))
+        from world.hp_chart import get_hp_from_chart
+        self._max_hp = get_hp_from_chart(self.body, self.willpower)
         self.death_save = self.body
         self.serious_wounds = self.body
 
@@ -753,7 +754,8 @@ class CharacterSheet(SharedMemoryModel):
         super().save(*args, **kwargs)
 
     def recalculate_derived_stats(self):
-        self._max_hp = 10 + (5 * ((self.body + self.willpower) // 2))
+        from world.hp_chart import get_hp_from_chart
+        self._max_hp = get_hp_from_chart(self.body, self.willpower)
         self.death_save = self.body
         self.serious_wounds = self.body
 

--- a/world/hp_chart.py
+++ b/world/hp_chart.py
@@ -1,0 +1,41 @@
+"""
+HP (Hit Points) lookup table per Cyberpunk Red rules.
+HP is determined by BODY (2-15) and WILL (2-10).
+Values outside range are clamped to the nearest valid index.
+"""
+
+# HP chart: [WILL][BODY] - WILL 2-10 (index 0-8), BODY 2-15 (index 0-13)
+# Rows = WILL 2..10, Cols = BODY 2..15
+HP_CHART = [
+    # WILL 2: BODY 2-15
+    [20, 25, 25, 30, 30, 35, 35, 40, 40, 45, 45, 50, 50, 55],
+    # WILL 3
+    [25, 25, 30, 30, 35, 35, 40, 40, 45, 45, 50, 50, 55, 55],
+    # WILL 4
+    [25, 30, 30, 35, 35, 40, 40, 45, 45, 50, 50, 55, 55, 60],
+    # WILL 5
+    [30, 30, 35, 35, 40, 40, 45, 45, 50, 50, 55, 55, 60, 60],
+    # WILL 6
+    [30, 35, 35, 40, 40, 45, 45, 50, 50, 55, 55, 60, 60, 65],
+    # WILL 7
+    [35, 35, 40, 40, 45, 45, 50, 50, 55, 55, 60, 60, 65, 65],
+    # WILL 8
+    [35, 40, 40, 45, 45, 50, 50, 55, 55, 60, 60, 65, 65, 70],
+    # WILL 9
+    [40, 40, 45, 45, 50, 50, 55, 55, 60, 60, 65, 65, 70, 70],
+    # WILL 10
+    [40, 45, 45, 50, 50, 55, 55, 60, 60, 65, 65, 70, 70, 75],
+]
+
+
+def get_hp_from_chart(body, willpower):
+    """
+    Look up HP from the official chart. BODY 2-15, WILL 2-10.
+    Values outside range are clamped to the nearest valid index.
+    """
+    body = int(body or 0)
+    willpower = int(willpower or 0)
+    # Clamp to chart range: BODY 2-15, WILL 2-10
+    body_idx = max(0, min(13, body - 2))
+    will_idx = max(0, min(8, willpower - 2))
+    return HP_CHART[will_idx][body_idx]

--- a/world/utils/character_utils.py
+++ b/world/utils/character_utils.py
@@ -322,17 +322,31 @@ def fuzzy_match_skill(input_str):
     return None, []
 
 
+# Skills that require an instance for rolls (e.g. local_expert(The Net), play_instrument(Guitar))
+SKILLS_REQUIRING_INSTANCE = frozenset(["local_expert", "play_instrument", "martial_arts"])
+
+
 def fuzzy_match_stat_or_skill(input_str):
     """
     Fuzzy match input to a stat or skill (interchangeable for roll).
     Tries stat first, then skill. Returns (full_name, None) if unique match,
     or (None, [display_names]) if multiple matches. (None, []) if no match.
+    Supports skill instances: "local expert (The Net)" -> local_expert(The Net).
     """
-    stat_match, stat_ambiguous = fuzzy_match_stat(input_str)
+    base_input = input_str
+    instance_part = None
+    if input_str and "(" in input_str and ")" in input_str:
+        idx = input_str.index("(")
+        base_input = input_str[:idx].strip()
+        instance_part = input_str[idx + 1 : input_str.rindex(")")].strip()
+
+    stat_match, stat_ambiguous = fuzzy_match_stat(base_input)
     if stat_match:
         return stat_match, None
-    skill_match, skill_ambiguous = fuzzy_match_skill(input_str)
+    skill_match, skill_ambiguous = fuzzy_match_skill(base_input)
     if skill_match:
+        if skill_match in SKILLS_REQUIRING_INSTANCE and instance_part:
+            return f"{skill_match}({instance_part})", None
         return skill_match, None
     if stat_ambiguous or skill_ambiguous:
         combined = list(dict.fromkeys((stat_ambiguous or []) + (skill_ambiguous or [])))


### PR DESCRIPTION
Rather than forcing the system to calculate HP directly, I recreated the HP chart on pg. 79 of the corebook. This should provide the accurate HP information. Changed the CHARGEN_STAT_MIN from 2 to 0 so as to allow people to remove skills that they don't want.

That said, chargen/finish will check to make sure that players have at least a 2 in the following skills as per the core Cyberpunk RED rules (pg. 90): _Athletics, Brawling, Concentration, Conversation, Education, Evasion, First Aid, Human Perception, Local Expert (Instance), Perception, Persuasion, Stealth_ Players are also required to have at least 2 points in Streetslang.

If you do not have those, chargen/finish will throw an error message and explain that you need to have at least 2 points in those core skills.

For the NoneType issue, it was as soon as a character is created. The at_object_creation call for characters never set self.db.languages. The attribute itself might exist but return None, so hasattr(self.db, 'languages') stays True and the code skipped initialization. The code then does languages = self.db.languages (which is None), then languages[language_name] = level, which throws that error. NoneType object (character.db.languages) does not support item assignment (it's an uninitialized list and thus defaults to the word 'None'). To fix this, new characters now get self.db.languages = {} when created. This also should prevent the 'None' from being entered into the dict when it's empty.

Cyberpunk Red has a bunch of pointless skill names. Style & Wardrobe is a _really long_ and sort of silly skill name, so I changed it to Style. Style implies wardrobe anyway. One other skill that shows up like this is Artistry and Photography. Rather than the clumsily-named **Paint/Draw/Sculpt**, I elected to use **Artistry**. It's effectively the same thing. **Photography** comes from the skill **Photography/Film**. Like the other skills that have a forward slash, it's an unnecessary specification. Plus, slashes don't work too well as database items.

Aside from that, **Science** has been split up among a series of different science-based skills (including soft sciences). This is because I was, initially, confused about doing instancing. I'm much better at that now, so could refactor it to work with that but I also feel like it doesn't hurt anything as it is.

Finally, you can now roll with an instance specified.